### PR TITLE
Update Native CTR Alerts.yaml

### DIFF
--- a/.github/workflows/Native CTR Alerts.yaml
+++ b/.github/workflows/Native CTR Alerts.yaml
@@ -2,8 +2,8 @@ name: 📊 AdMob Network → BigQuery + Native CTR Alerts
 
 on:
   schedule:
-    # Runs every hour per day - UTC
-    - cron: '0 * * * *'
+    # Runs twice a day at 00:00 UTC and 12:00 UTC
+    - cron: '0 0,12 * * *'
   workflow_dispatch:
     inputs:
       run_date:


### PR DESCRIPTION
Changed the workflow to run twice a day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow schedule to run twice daily at midnight and noon UTC instead of every hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->